### PR TITLE
Fix: Import ClientAuthScreen in checkout_screen.dart

### DIFF
--- a/lib/screens/client/checkout_screen.dart
+++ b/lib/screens/client/checkout_screen.dart
@@ -17,6 +17,7 @@ import 'package:geocoding/geocoding.dart';
 import 'package:food_delivery_app/screens/client/order_tracking_screen.dart';
 import 'package:food_delivery_app/screens/client/client_home_screen.dart'; // <<< ADD THIS LINE
 import 'package:food_delivery_app/screens/profile/profile_screen.dart';
+import 'package:food_delivery_app/screens/client/client_auth_screen.dart';
 
 
 class CheckoutScreen extends StatefulWidget {


### PR DESCRIPTION
The build was failing because `checkout_screen.dart` was trying to use `ClientAuthScreen` without importing it.

This commit adds the missing import statement, which resolves the compilation error.